### PR TITLE
 Add configuration block with default params to Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ rake dataclips:install:migrations
 rake db:migrate
 ```
 
+## Configuration
+You can configure Dataclips' Insights with default params via configuration block
+```ruby
+Dataclips::Insight.configure do |config|
+  config.default_params = { my_param: "my default value" }
+end
+```
+and the `my_param` will always be there. You can easily override the default param by passing a param with the same name, like so:
+```ruby
+  Dataclips::Insight.get!("my_clip", my_param: "new value")
+```
+
+It is also possible to configure the default params with dynamic values by passing a callable object to them, e.g.
+```ruby
+Dataclips::Insight.configure do |config|
+  config.default_params = { my_param: -> { Time.now } }
+end
+```
+and the value will be evaluated on-the-fly.
+
 ## Mount engine (config/routes.rb)
 
 ```ruby

--- a/app/models/dataclips/insight.rb
+++ b/app/models/dataclips/insight.rb
@@ -1,6 +1,25 @@
 module Dataclips
   class Insight < ActiveRecord::Base
     class FileNotFound < ArgumentError; end
+    class Config
+      # @return [Hash{Symbol=>Any}] default parameters that can be set app-wise (and changed if required). Supports dynamic values (via callable objects)
+      # @api public
+      attr_accessor :default_params
+
+      def initialize(user_config = {})
+        self.default_params = user_config[:default_params] || {}
+      end
+    end
+
+    class << self
+      def configure
+        yield @config = Config.new
+      end
+
+      def config
+        @config ||= Config.new
+      end
+    end
 
     validates :clip_id, presence: true
     validates :hash_id, presence: true, uniqueness: true
@@ -21,9 +40,14 @@ module Dataclips
     end
 
     def self.get!(clip_id, params = {}, options = {})
+      params = {
+        **config.default_params,
+        **params.symbolize_keys,
+      }.transform_values { |v| v.respond_to?(:call) ? v.call : v }
+
       schema    = options[:schema]
 
-      clip      = Clip.new(clip_id, schema) 
+      clip      = Clip.new(clip_id, schema)
       name      = options.fetch(:name, clip.name || clip_id)
 
       checksum = calculate_checksum(clip_id, params, schema)
@@ -31,7 +55,7 @@ module Dataclips
         return insight
       else
         hash_id = SecureRandom.urlsafe_base64(6)
-        
+
         if basic_auth = options[:basic_auth]
           if basic_auth[:username].present? && basic_auth[:password].present?
             basic_auth_credentials = [basic_auth[:username], basic_auth[:password]].join(":")

--- a/db/migrate/20150101143530_create_dataclips_insights.rb
+++ b/db/migrate/20150101143530_create_dataclips_insights.rb
@@ -1,4 +1,4 @@
-class CreateDataclipsInsights < ActiveRecord::Migration
+class CreateDataclipsInsights < ActiveRecord::Migration[4.2]
   def change
     create_table :dataclips_insights do |t|
       t.string  :clip_id, null: false

--- a/test/dummy/app/dataclips/dummy.sql
+++ b/test/dummy/app/dataclips/dummy.sql
@@ -1,0 +1,1 @@
+SELECT * FROM dataclips_insights;

--- a/test/dummy/app/dataclips/dummy.yml
+++ b/test/dummy/app/dataclips/dummy.yml
@@ -1,0 +1,22 @@
+schema:
+  clip_id:
+    type: text
+    sortable: true
+  checksum:
+    type: text
+    sortable: true
+  name:
+    type: text
+    sortable: true
+  hash_id:
+    type: text
+    sortable: true
+  schema:
+    type: text
+    sortable: true
+  time_zone:
+    type: text
+    sortable: true
+  params:
+    type: object
+    sortable: true

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -5,21 +5,22 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  host: localhost
+  encoding: unicode
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: dataclips_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: dataclips_test
 
 production:
-  <<: *default
-  database: db/production.sqlite3
+  url:  <%= ENV["DATABASE_URL"] %>

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,0 +1,36 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150101143530) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "dataclips_insights", id: :serial, force: :cascade do |t|
+    t.string "clip_id", null: false
+    t.string "schema"
+    t.string "hash_id", null: false
+    t.string "checksum", null: false
+    t.string "time_zone"
+    t.string "name"
+    t.string "basic_auth_credentials"
+    t.json "params"
+    t.datetime "last_viewed_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["checksum"], name: "index_dataclips_insights_on_checksum", unique: true
+    t.index ["clip_id"], name: "index_dataclips_insights_on_clip_id"
+    t.index ["hash_id"], name: "index_dataclips_insights_on_hash_id", unique: true
+    t.index ["schema"], name: "index_dataclips_insights_on_schema"
+  end
+
+end

--- a/test/models/dataclips/insight_test.rb
+++ b/test/models/dataclips/insight_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class Dataclips::InsightTest < ActiveSupport::TestCase
+  class DefaultParams < ActiveSupport::TestCase
+    teardown do
+      # Make sure we work with pristine config each time
+      Dataclips::Insight.remove_instance_variable(:@config)
+    end
+
+    test "configuring via configuration block" do
+      Dataclips::Insight.configure do |config|
+        config.default_params = {test: "test"}
+      end
+
+      expected_params = {test: "test"}
+      assert_equal expected_params, Dataclips::Insight.config.default_params
+    end
+
+    test "assigning empty hash to default params by default" do
+      assert_equal Hash.new, Dataclips::Insight.config.default_params
+      insight = Dataclips::Insight.get!("dummy")
+      assert_equal Hash.new, insight.params
+    end
+
+    test "merging default params with those provided by the user" do
+      Dataclips::Insight.config.default_params = { test: "test" }
+      symbol_insight = Dataclips::Insight.get!("dummy", id: 1)
+      string_insight = Dataclips::Insight.get!("dummy", "id" => 1)
+      expected_params = { "test" => "test", "id" => 1}
+      assert_equal expected_params, symbol_insight.params
+      assert_equal expected_params, string_insight.params
+    end
+
+    test "overriding default params" do
+      Dataclips::Insight.config.default_params = { test: "test" }
+      symbol_insight = Dataclips::Insight.get!("dummy", test: 1)
+      string_insight = Dataclips::Insight.get!("dummy", "test" => 1)
+      expected_params = { "test" => 1 }
+      assert_equal expected_params, symbol_insight.params
+      assert_equal expected_params, string_insight.params
+    end
+
+    test "setting dynamic default params values" do
+      Dataclips::Insight.config.default_params = {
+        test: -> { Thread.current[:test_value] },
+      }
+
+      Thread.current[:test_value] = "test"
+      insight = Dataclips::Insight.get!("dummy")
+      expected_params = { "test" => "test" }
+      assert_equal expected_params, insight.params
+
+      Thread.new do
+        Thread.current[:test_value] = "other value"
+        insight = Dataclips::Insight.get!("dummy")
+        expected_params = { "test" => "other value" }
+        assert_equal expected_params, insight.params
+      end
+    end
+  end
+end


### PR DESCRIPTION
With the config block it becomes possible to attach default params, so
dataclips can be scoped and run in a certain context, for example in SaaS
environments. It simplifies usage in a great deal because one doesn't
have to pass the same param over and over again. It also supports dynamic
values evaluated on-the-fly.

I've used separate configure block (instead of `Dataclips::Engine`) to
loosen a little the hard dependency on Rails. The gem might be used in
other envs as well, so it doesn't have to be tied that hard to Rails.

Changes to `dummy_app` and migration file were required to boot test suite